### PR TITLE
Add dynamic k-means target positions

### DIFF
--- a/source/shaders/physics.fs
+++ b/source/shaders/physics.fs
@@ -1,12 +1,35 @@
 precision mediump float;
 uniform sampler2D physicsData;
 uniform vec2 bounds;
-const vec3 TARGET = vec3(0, 0, 0.01);
+uniform vec3 targets[5];
+uniform int targetCount;
 const int POSITION_SLOT = 0;
 const int VELOCITY_SLOT = 1;
 vec4 texel(vec2 offset) {
   vec2 coord = (gl_FragCoord.xy + offset) / bounds;
   return texture2D(physicsData, coord);
+}
+
+vec3 nearestTarget(vec3 position) {
+  vec3 best = targets[0];
+  float bestDist = distance(position, targets[0]);
+  if (targetCount > 1) {
+    float d = distance(position, targets[1]);
+    if (d < bestDist) { bestDist = d; best = targets[1]; }
+  }
+  if (targetCount > 2) {
+    float d = distance(position, targets[2]);
+    if (d < bestDist) { bestDist = d; best = targets[2]; }
+  }
+  if (targetCount > 3) {
+    float d = distance(position, targets[3]);
+    if (d < bestDist) { bestDist = d; best = targets[3]; }
+  }
+  if (targetCount > 4) {
+    float d = distance(position, targets[4]);
+    if (d < bestDist) { bestDist = d; best = targets[4]; }
+  }
+  return best;
 }
 void main() {
   int slot = int(mod(gl_FragCoord.x, 2.0));
@@ -18,7 +41,8 @@ void main() {
     float phase = dataA.w;
     if (phase > 0.0) {
       position += velocity * 0.005;
-      if (length(TARGET - position) < 0.035) phase = 0.0;
+      vec3 t = nearestTarget(position);
+      if (length(t - position) < 0.035) phase = 0.0;
       else phase += 0.1;
     } else {
       position = vec3(-1);
@@ -31,7 +55,8 @@ void main() {
     vec3 velocity = dataB.xyz;
     float phase = dataA.w;
     if (phase > 0.0) {
-      vec3 delta = normalize(TARGET - position);
+      vec3 t = nearestTarget(position);
+      vec3 delta = normalize(t - position);
       velocity += delta * 0.05;
       velocity *= 0.991;
     } else {


### PR DESCRIPTION
## Summary
- cluster incoming positions via k-means and store up to five target centers
- send target center data to the physics shader each frame
- update physics shader to move particles toward nearest target
- handle WebSocket data by computing clusters and updating shader targets

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68460a7d508483338de163511a763a05